### PR TITLE
🌍 Add additional open graph protocol properties to website

### DIFF
--- a/src/overrides/home.html
+++ b/src/overrides/home.html
@@ -1,6 +1,8 @@
 {% extends "main.html" %}
 
 {% block extrahead %}
+<meta property="og:site_name" content="Engineering Collaboration" />
+<meta property="og:type" content="website" />
 <script type="application/ld+json">
 [
   {

--- a/src/overrides/main.html
+++ b/src/overrides/main.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 
 {% block extrahead %}
+{{ super() }}
+
+<meta property="og:site_name" content="Engineering Collaboration" />
+<meta property="og:type" content="website" />
 {% if page.meta and page.meta.title %} 
 <script type="application/ld+json">
     {


### PR DESCRIPTION
# Summary

Add the `site_name` and `type` properties to the landing page and all book chapters. From the OG protocol:

- `og:site_name` - If your object is part of a larger web site, the name which should be displayed for the overall site. e.g., "IMDb".
