### PR TITLE
🌍 Reactivate search in distributed book

### DIFF
--- a/mkdocs-dist.yml
+++ b/mkdocs-dist.yml
@@ -46,6 +46,9 @@ theme:
     - navigation.instant.progress
     - navigation.indexes
     - navigation.tabs
+    - search.suggest
+    - search.highlight
+    - search.share
 
 extra:
   social:
@@ -60,6 +63,7 @@ extra_css:
   - assets/extra.css
 
 plugins:
+  - search
   - social:
       cards_layout_options:
         background_color: "#14151A"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,9 @@ theme:
     - navigation.instant.progress
     - navigation.indexes
     - navigation.tabs
+    - search.suggest
+    - search.highlight
+    - search.share
 
 extra:
   social:
@@ -58,6 +61,9 @@ extra:
 
 extra_css:
   - assets/extra.css
+
+plugins:
+  - search
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
# Summary

The search bar does not appear in the distributed online version of the book since we added the social cards.

According to the Material for MkDocs documentation:

The built-in search plugin integrates seamlessly with Material for MkDocs, adding multilingual client-side search with [lunr](https://lunrjs.com/) and [lunr-languages](https://github.com/MihaiValentin/lunr-languages). It's enabled by default, ***but must be re-added to mkdocs.yml when other plugins are used***:

```yaml
plugins:
  - search
 ```
